### PR TITLE
Fix memory leaks from compiled_re_list

### DIFF
--- a/pappl-retrofit/pappl-retrofit.c
+++ b/pappl-retrofit/pappl-retrofit.c
@@ -254,7 +254,10 @@ prBestMatchingPPD(const char *device_id,	// I - IEEE-1284 device ID
     {
       for (re = (regex_t *)cupsArrayGetFirst(compiled_re_list);
 	   re; re = (regex_t *)cupsArrayGetNext(compiled_re_list))
+      {
 	regfree(re);
+	free(re);
+      }
       cupsArrayDelete(compiled_re_list);
     }
   }


### PR DESCRIPTION
We don't define any memory freeing function for the list, and use two allocation functions for members - calloc() and regcomp() - we have to free both.