### PR TITLE
BUG: Fix bug where O_NONBLOCK flag is set with the wrong fcntl

### DIFF
--- a/pappl-retrofit/cups-backends.c
+++ b/pappl-retrofit/cups-backends.c
@@ -417,8 +417,8 @@ _prCUPSDevList(pappl_device_cb_t cb,
       // over the end of an output line before the backend terminates that we
       // do not get blocked until the next output line or the end of this
       // backend
-      if (fcntl(backend->pipe, F_SETFD,
-		fcntl(backend->pipe, F_GETFD) | O_NONBLOCK))
+      if (fcntl(backend->pipe, F_SETFL,
+		fcntl(backend->pipe, F_GETFL) | O_NONBLOCK))
       {
 	_prCUPSDevLog(&devlog_data, PAPPL_LOGLEVEL_ERROR,
 		      "Unable to set output pipe of '%s' to non-blocking- %s\n",


### PR DESCRIPTION
F_SETFD is for descriptor flags and FD_CLOEXEC is the only valid descriptor flag.
F_SETFL is for status flags, including O_NONBLOCK