### PR TITLE
  ci: expand build.yml to 4-arch matrix (amd64, arm64, armhf, riscv64)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,40 +1,47 @@
 # =============================================================================
-# Build and Test Workflow for pappl-retrofit  (x86_64 / ubuntu-latest)
+# Multi-Architecture Build & Test Workflow for pappl-retrofit
 #
-# Modelled on the libppd / libcupsfilters CI workflows in the sister
-# OpenPrinting repositories.  Scope is intentionally restricted to a single
-# native architecture (x86_64 on ubuntu-latest) so the build runs quickly
-# and deterministically while still proving:
+# Modelled on the QEMU-based CI used in the sister OpenPrinting repositories
+# (libppd, libcupsfilters, cups-filters).  Proves on every push / PR / manual
+# dispatch that pappl-retrofit compiles end-to-end (libpappl-retrofit.la +
+# legacy-printer-app + every check_PROGRAMS binary) and that every registered
+# TEST in Makefile.am passes under `make check V=1 VERBOSE=1` on FOUR
+# architectures:
 #
-#   * The complete repository compiles end-to-end (libpappl-retrofit.la,
-#     legacy-printer-app, plus every entry in check_PROGRAMS / TESTS) —
-#     not just that the test binaries link against an already-built
-#     library.
-#   * Every registered TEST passes (the hermetic C unit tests:
-#     test_backend_parse, test_ascii85, test_devid_match).
-#   * legacy-printer-app launches and responds to --help, catching
-#     ABI / symbol-resolution regressions against the runtime PAPPL,
-#     libcupsfilters and libppd packages.
+#   * amd64    - native, ubuntu-latest
+#   * arm64    - native, ubuntu-24.04-arm
+#   * armhf    - emulated via QEMU (armv7)
+#   * riscv64  - emulated via QEMU
 #
-# The apt package list was derived from a direct scan of configure.ac:
+# The hermetic C unit tests exercised:
+#   * test_backend_parse  - cups-backends.c helpers
+#                           (_prDummyDevice, _prGetCurrentTime,
+#                            _prCUPSCompareDevices)
+#   * test_ascii85        - _prASCII85 encoder in print-job.c
+#                           (line wrap, padding, multi-call accumulator)
+#   * test_devid_match    - prRegExMatchDevIDField + prSupports* PDL
+#                           detectors in pappl-retrofit.c
 #
-#   * PKG_CHECK_MODULES([PAPPL], [pappl])                  -> libpappl-dev
-#   * PKG_CHECK_MODULES([CUPSFILTERS], [libcupsfilters])   -> libcupsfilters-dev
-#   * PKG_CHECK_MODULES([PPD], [libppd])                   -> libppd-dev
-#   * AC_PATH_TOOL(CUPSCONFIG, [cups-config]) (cups3 absent
-#     on ubuntu-latest, falls back to libcups2)            -> libcups2-dev
-#   * AM_GNU_GETTEXT([external]) / AM_ICONV                -> gettext, autopoint
-#   * AC_PROG_CC, AM_PROG_CC_C_O                           -> build-essential
-#   * LT_INIT                                              -> libtool, libtool-bin
-#   * PKG_PROG_PKG_CONFIG                                  -> pkg-config
-#   * AC_PROG_INSTALL                                      -> (build-essential)
-#   * autotools toolchain                                  -> autoconf, automake
+# Plus a smoke-test of `legacy-printer-app --help` to catch ABI /
+# symbol-resolution regressions against the runtime PAPPL / libppd /
+# libcupsfilters stack.
 #
-# zlib1g-dev is included to satisfy the AC_CHECK_HEADERS([zlib.h]) probe
-# (pulled in transitively by libcupsfilters anyway).
+# apt package list derived from configure.ac:
+#   PKG_CHECK_MODULES([PAPPL])              -> libpappl-dev (apt) OR
+#                                              PAPPL v1.4.10 built from source
+#                                              in QEMU legs where apt's
+#                                              libpappl-dev may lag
+#   PKG_CHECK_MODULES([CUPSFILTERS])        -> libcupsfilters-dev
+#   PKG_CHECK_MODULES([PPD])                -> libppd-dev
+#   AC_PATH_TOOL(CUPSCONFIG)                -> libcups2-dev
+#   AM_GNU_GETTEXT([external])              -> gettext, autopoint
+#   AC_PROG_CC / LT_INIT / pkg-config       -> build-essential, autoconf,
+#                                              automake, libtool,
+#                                              libtool-bin, pkg-config
+#   AC_CHECK_HEADERS([zlib.h])              -> zlib1g-dev
 # =============================================================================
 
-name: Build and Test (pappl-retrofit)
+name: Build and Test (pappl-retrofit, multi-arch)
 
 on:
   push:
@@ -47,24 +54,44 @@ on:
 
 jobs:
   build:
-    name: Build & Test (x86_64)
-    runs-on: ubuntu-latest
+    name: Build & Test (${{ matrix.arch }})
+    runs-on: ${{ matrix.runs-on }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runs-on: ubuntu-latest
+            use-qemu: false
+          - arch: arm64
+            runs-on: ubuntu-24.04-arm
+            use-qemu: false
+          - arch: armhf
+            runs-on: ubuntu-latest
+            use-qemu: true
+            qemu-arch: armv7
+          - arch: riscv64
+            runs-on: ubuntu-latest
+            use-qemu: true
+            qemu-arch: riscv64
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Save workspace directory
+        run: echo "REPO_DIR=$(pwd)" >> $GITHUB_ENV
+
       # -----------------------------------------------------------------------
-      # System dependencies — derived from configure.ac (see header comment).
-      # Note: libppd-dev and libpappl-dev availability depends on the runner's
-      # apt sources.  On stock ubuntu-latest both ship for 24.04+.  If a future
-      # runner image drops one of them, pin the runner version (e.g.
-      # ubuntu-24.04) or add the OpenPrinting PPA before this step.
+      # NATIVE LEG  (amd64 on ubuntu-latest, arm64 on ubuntu-24.04-arm)
       # -----------------------------------------------------------------------
-      - name: Install build & runtime dependencies
+      - name: Install dependencies (native)
+        if: matrix.use-qemu == false
         run: |
           set -ex
-          sudo apt-get update --fix-missing -y
+          sudo apt-get clean
+          sudo apt-get update --fix-missing -y -o Acquire::Retries=3
           sudo apt-get install -y --no-install-recommends \
             build-essential \
             autoconf \
@@ -74,70 +101,130 @@ jobs:
             libtool-bin \
             pkg-config \
             gettext \
+            git \
+            wget \
+            tar \
             libcups2-dev \
             libcupsfilters-dev \
             libppd-dev \
             libpappl-dev \
             zlib1g-dev
 
-      # -----------------------------------------------------------------------
-      # Full build — autogen.sh regenerates configure / Makefile.in from the
-      # autotools sources; configure runs without --disable-* flags so every
-      # configure-time probe is exercised; make -j$(nproc) builds the library,
-      # legacy-printer-app, AND every check_PROGRAMS test binary, surfacing
-      # any compiler errors or warnings as build output.
-      # -----------------------------------------------------------------------
-      - name: autogen.sh
-        run: ./autogen.sh
-
-      - name: configure
-        run: ./configure
-
-      - name: make
-        run: make -j$(nproc) V=1
-
-      # -----------------------------------------------------------------------
-      # Run the registered TESTS.  V=1 and VERBOSE=1 expose both the compile
-      # line per object AND each test's stderr in the workflow log on failure,
-      # matching the libcupsfilters / libppd CI pattern.  test-suite.log is
-      # cat'd inline on failure so the workflow output itself shows the
-      # automake summary even before the artifact-upload step runs.
-      # -----------------------------------------------------------------------
-      - name: make check
-        id: check
+      - name: Build & test pappl-retrofit (native)
+        if: matrix.use-qemu == false
         run: |
-          set -o pipefail
+          set -ex
+          cd "$REPO_DIR"
+          ./autogen.sh
+          ./configure
+          make -j$(nproc) V=1
           make check V=1 VERBOSE=1 || {
             echo "==== test-suite.log ===="
             test -f test-suite.log && cat test-suite.log
             echo "==== per-test logs ===="
-            for f in pappl-retrofit/*.log; do
-              [ -f "$f" ] || continue
-              echo "---- $f ----"
-              cat "$f"
+            for f in $(find . -name '*.log' -not -name 'config.log'); do
+              echo "---- $f ----"; cat "$f"
             done
             exit 1
           }
 
-      # -----------------------------------------------------------------------
-      # Smoke-test legacy-printer-app — proves the linked binary actually
-      # loads against the runtime PAPPL / libppd / libcupsfilters and that
-      # CLI entry points still work.  --help exits 0 on success and prints
-      # the usage banner; any dlopen / undefined-symbol failure surfaces here.
-      # -----------------------------------------------------------------------
-      - name: Smoke-test legacy-printer-app --help
-        run: ./legacy-printer-app --help
+      - name: Smoke-test legacy-printer-app --help (native)
+        if: matrix.use-qemu == false
+        run: |
+          set -ex
+          cd "$REPO_DIR"
+          ./legacy-printer-app --help
 
       # -----------------------------------------------------------------------
-      # Artifact upload — only fires when `make check` failed.  Captures the
-      # top-level test-suite.log automake produces plus any per-test .log /
-      # .trs files so the failure can be diagnosed offline.
+      # EMULATED LEG  (armhf via QEMU armv7, riscv64 via QEMU)
+      #
+      # PAPPL is built from source (v1.4.10, same pin as the CodeQL workflow)
+      # because apt's libpappl-dev coverage on non-amd64 / non-arm64 Ubuntu
+      # ports can lag and breaks PKG_CHECK_MODULES([pappl]).
       # -----------------------------------------------------------------------
-      - name: Upload test-suite.log on failure
-        if: failure() && steps.check.conclusion == 'failure'
+      - name: Set up QEMU
+        if: matrix.use-qemu == true
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: ${{ matrix.qemu-arch }}
+
+      - name: Build & test pappl-retrofit (emulated)
+        if: matrix.use-qemu == true
+        uses: uraimo/run-on-arch-action@v3
+        with:
+          arch: ${{ matrix.qemu-arch }}
+          distro: ubuntu24.04
+          dockerRunArgs: |
+            --volume "${{ github.workspace }}:/workspace"
+          install: |
+            apt-get clean
+            apt-get update --fix-missing -y -o Acquire::Retries=3
+            DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata
+            apt-get install -y --no-install-recommends \
+              build-essential \
+              gcc g++ \
+              autoconf \
+              automake \
+              autopoint \
+              libtool \
+              libtool-bin \
+              pkg-config \
+              gettext \
+              git \
+              wget \
+              tar \
+              libcups2-dev \
+              libcupsfilters-dev \
+              libppd-dev \
+              libavahi-client-dev \
+              libjpeg-dev \
+              libpng-dev \
+              libusb-1.0-0-dev \
+              libpam-dev \
+              libssl-dev \
+              zlib1g-dev
+          run: |
+            set -ex
+            export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig:/usr/lib/pkgconfig
+
+            # Build PAPPL v1.4.10 from source (matches CodeQL workflow pin)
+            cd /tmp
+            git clone --branch v1.4.10 --depth 1 https://github.com/michaelrsweet/pappl.git
+            cd pappl
+            ./configure --enable-shared
+            make -j$(nproc)
+            make install
+            ldconfig
+
+            # Verify PAPPL is discoverable via pkg-config inside the container
+            pkg-config --modversion pappl
+
+            # Build and test pappl-retrofit
+            cd /workspace
+            ./autogen.sh
+            ./configure
+            make -j$(nproc) V=1
+            make check V=1 VERBOSE=1 || {
+              echo "==== test-suite.log ===="
+              test -f test-suite.log && cat test-suite.log
+              echo "==== per-test logs ===="
+              for f in $(find . -name '*.log' -not -name 'config.log'); do
+                echo "---- $f ----"; cat "$f"
+              done
+              exit 1
+            }
+
+            # Smoke-test the linked binary
+            ./legacy-printer-app --help
+
+      # -----------------------------------------------------------------------
+      # ARTIFACT UPLOAD (all four legs, only on failure)
+      # -----------------------------------------------------------------------
+      - name: Upload test logs on failure
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: pappl-retrofit-test-suite-log-x86_64
+          name: pappl-retrofit-test-logs-${{ matrix.arch }}
           path: |
             test-suite.log
             **/*.log

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,6 +161,7 @@ jobs:
             apt-get update --fix-missing -y -o Acquire::Retries=3
             DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata
             apt-get install -y --no-install-recommends \
+              ca-certificates \
               build-essential \
               gcc g++ \
               autoconf \
@@ -183,6 +184,7 @@ jobs:
               libpam-dev \
               libssl-dev \
               zlib1g-dev
+            update-ca-certificates
           run: |
             set -ex
             export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig:/usr/lib/pkgconfig


### PR DESCRIPTION
## Summary
  - Expand `build.yml` from x86_64-only to a 4-arch matrix: amd64 + arm64 native, armhf + riscv64 via QEMU 
  (`uraimo/run-on-arch-action@v3`).
  - Every leg runs `make -j$(nproc) V=1` → `make check V=1 VERBOSE=1` (covers `test_backend_parse`, `test_ascii85`,
  `test_devid_match`) → `./legacy-printer-app --help` smoke-test.
  - QEMU legs build PAPPL v1.4.10 from source (apt's `libpappl-dev` lags on armhf/riscv64 ports) and install `ca-certificates`
  so HTTPS `git clone` works inside the minimal base images.
  - On `make check` failure: per-test logs are dumped inline and uploaded as artifacts (14-day retention).

  ## Test plan
  - [x] amd64, arm64, armhf, riscv64 all green
  - [x] All 3 unit tests pass on every arch
  - [x] `legacy-printer-app --help` smoke-test passes on every arch