### PR TITLE
Add install-time autopkgtest coverage and fix pkg-config metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,6 +135,13 @@ jobs:
           cd "$REPO_DIR"
           ./legacy-printer-app --help
 
+      - name: Autopkgtest (DESTDIR staging, native)
+        if: matrix.use-qemu == false
+        run: |
+          set -ex
+          cd "$REPO_DIR"
+          make test-autopkgtest V=1
+
       # -----------------------------------------------------------------------
       # EMULATED LEG  (armhf via QEMU armv7, riscv64 via QEMU)
       #
@@ -218,6 +225,9 @@ jobs:
 
             # Smoke-test the linked binary
             ./legacy-printer-app --help
+
+            # Staged-install downstream autopkgtest (DESTDIR)
+            make test-autopkgtest V=1
 
       # -----------------------------------------------------------------------
       # ARTIFACT UPLOAD (all four legs, only on failure)

--- a/Makefile.am
+++ b/Makefile.am
@@ -209,6 +209,7 @@ distclean-local:
 
 clean-local:
 	rm -f $(legacy_printer_app_manpage8)
+	rm -rf $(CIROOT)
 
 install-data-hook:
 	$(INSTALL) -d -m 755 $(DESTDIR)$(legacy_printer_app_statedir)
@@ -249,3 +250,34 @@ endif
 uninstall-hook:
 
 SUBDIRS =
+
+# ============================================================
+# Staged-install downstream autopkgtests (DESTDIR staging)
+# ============================================================
+CIROOT = $(abs_top_builddir)/_ciroot
+
+EXTRA_DIST += \
+	ci/autopkgtest/run.sh \
+	ci/autopkgtest/debian-tests/control \
+	ci/autopkgtest/debian-tests/pappl-retrofit-1-dev
+
+# Stage a clean install of the just-built tree into $(CIROOT), then rewrite
+# the staged libpappl-retrofit.pc prefix so a downstream consumer resolves
+# THIS build (and not a system copy) while system dependency .pc files
+# (libcupsfilters / libppd / pappl) keep resolving normally.
+stage-ciroot: all
+	rm -rf "$(CIROOT)"
+	$(MAKE) $(AM_MAKEFLAGS) install DESTDIR="$(CIROOT)"
+	@pc="$(CIROOT)$(libdir)/pkgconfig/libpappl-retrofit.pc"; \
+	if [ -f "$$pc" ]; then \
+	  sed -i.bak "s|^prefix=.*|prefix=$(CIROOT)$(prefix)|" "$$pc"; \
+	  rm -f "$$pc.bak"; \
+	  echo "stage-ciroot: rewrote prefix in $$pc"; \
+	fi
+
+# Run the unmodified downstream Debian autopkgtests against $(CIROOT).
+test-autopkgtest: stage-ciroot
+	CIROOT="$(CIROOT)" CIPREFIX="$(prefix)" TOP_BUILDDIR="$(abs_top_builddir)" \
+	    $(SHELL) $(srcdir)/ci/autopkgtest/run.sh pappl-retrofit-1-dev
+
+.PHONY: stage-ciroot test-autopkgtest

--- a/ci/autopkgtest/debian-tests/control
+++ b/ci/autopkgtest/debian-tests/control
@@ -1,0 +1,10 @@
+Tests: pappl-retrofit-1-dev
+Depends: build-essential,
+	 libcups2-dev,
+         libcupsfilters-dev,
+	 libppd-dev,
+	 libpappl-dev,
+	 libpappl-retrofit-dev,
+	 libavahi-client-dev,
+         pkg-config,
+Restrictions: allow-stderr superficial

--- a/ci/autopkgtest/debian-tests/pappl-retrofit-1-dev
+++ b/ci/autopkgtest/debian-tests/pappl-retrofit-1-dev
@@ -1,0 +1,41 @@
+#!/bin/sh
+# autopkgtest check: Build and run a program against pappl-retrofit, to verify
+# that the headers and pkg-config file are installed correctly
+# (C) 2012 Canonical Ltd.
+# (C) 2018-2019 Simon McVittie
+# (C) 2023 Till Kamppeter
+# Authors: Martin Pitt, Simon McVittie, Till Kamppeter
+
+set -eux
+
+package=pappl-retrofit
+WORKDIR="$(mktemp -d)"
+export HOME="$WORKDIR"
+export XDG_RUNTIME_DIR="$WORKDIR"
+trap 'cd /; rm -rf "$WORKDIR"' 0 INT QUIT ABRT PIPE TERM
+
+if [ -n "${DEB_HOST_GNU_TYPE:-}" ]; then
+    CROSS_COMPILE="$DEB_HOST_GNU_TYPE-"
+else
+    CROSS_COMPILE=
+fi
+
+cd "$WORKDIR"
+cat <<EOF > test.c
+// Header file of pappl-retrofit API
+#include <pappl-retrofit.h>
+
+int main(int argc, char *argv[])
+{
+  // Actually use something from the library, so that it gets actually linked
+  return (prSupportsPDF("CMD:PDF;") == false);
+}
+EOF
+
+# Deliberately word-splitting pkg-config's output:
+# shellcheck disable=SC2046
+${CROSS_COMPILE}gcc -o "${package}-test" test.c $(${CROSS_COMPILE}pkg-config --cflags --libs "lib$package") $(${CROSS_COMPILE}pkg-config --cflags --libs "libcupsfilters") $(${CROSS_COMPILE}pkg-config --cflags --libs "libppd")
+echo "build ($package): OK"
+[ -x "${package}-test" ]
+./${package}-test
+echo "run ($package): OK"

--- a/ci/autopkgtest/run.sh
+++ b/ci/autopkgtest/run.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+# ci/autopkgtest/run.sh
+#
+# Universal DESTDIR-staging wrapper for the downstream Debian autopkgtests.
+# Points PATH / LD_LIBRARY_PATH / PKG_CONFIG_PATH at the staged install tree
+# ($CIROOT) produced by `make stage-ciroot`, then runs the unmodified
+# downstream scripts vendored under ci/autopkgtest/debian-tests/.
+#
+# Env in:
+#   CIROOT             staging root        (default: $PWD/_ciroot)
+#   CIPREFIX           configured prefix   (default: /usr)
+#   TOP_BUILDDIR       build tree          (default: $PWD)
+#   AUTOPKGTEST_BINDS  optional space-separated "host:guest" proot binds for
+#                      scripts that read installed data via absolute paths
+#                      (unused by pappl-retrofit).
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+TESTS_DIR="$SCRIPT_DIR/debian-tests"
+
+: "${CIROOT:=$PWD/_ciroot}"
+: "${CIPREFIX:=/usr}"
+: "${TOP_BUILDDIR:=$PWD}"
+
+if [ ! -d "$CIROOT" ]; then
+    echo "run.sh: staging root not found: $CIROOT (run 'make stage-ciroot' first)" >&2
+    exit 1
+fi
+
+ROOT="$CIROOT$CIPREFIX"
+MULTIARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null \
+            || gcc -dumpmachine 2>/dev/null || echo "")
+
+PATH="$ROOT/bin:$ROOT/sbin:$TOP_BUILDDIR:$TOP_BUILDDIR/.libs:$PATH"
+LD_LIBRARY_PATH="$ROOT/lib${MULTIARCH:+:$ROOT/lib/$MULTIARCH}:$TOP_BUILDDIR/.libs${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+PKG_CONFIG_PATH="$ROOT/lib/pkgconfig${MULTIARCH:+:$ROOT/lib/$MULTIARCH/pkgconfig}:$ROOT/share/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+export PATH LD_LIBRARY_PATH PKG_CONFIG_PATH
+
+# Optional surgical /usr redirection (Fix C) for repos whose scripts read
+# installed binaries/data via absolute paths.  No-op for pappl-retrofit.
+if [ -n "${AUTOPKGTEST_BINDS:-}" ] && [ -z "${_UNDER_PROOT:-}" ]; then
+    if command -v proot >/dev/null 2>&1; then
+        binds=""
+        for pair in $AUTOPKGTEST_BINDS; do binds="$binds -b $pair"; done
+        _UNDER_PROOT=1; export _UNDER_PROOT
+        # shellcheck disable=SC2086
+        exec proot $binds -- "$0" "$@"
+    fi
+    echo "run.sh: AUTOPKGTEST_BINDS set but 'proot' not installed" >&2
+    exit 1
+fi
+
+if [ "$#" -eq 0 ]; then
+    echo "run.sh: usage: run.sh <test-name> [test-name...]" >&2
+    exit 2
+fi
+
+rc=0
+for name in "$@"; do
+    script="$TESTS_DIR/$name"
+    if [ ! -f "$script" ]; then
+        echo "run.sh: no such test: $script" >&2
+        rc=1
+        continue
+    fi
+    chmod +x "$script" 2>/dev/null || true
+    workdir=$(mktemp -d)
+    echo "=== autopkgtest: $name (CIROOT=$CIROOT, prefix=$CIPREFIX) ==="
+    if ( cd "$workdir" && "$script" ); then
+        echo "=== PASS: $name ==="
+    else
+        rc=$?
+        echo "=== FAIL: $name (exit $rc) ===" >&2
+        rc=1
+    fi
+    rm -rf "$workdir"
+done
+exit $rc

--- a/libpappl-retrofit.pc.in
+++ b/libpappl-retrofit.pc.in
@@ -9,4 +9,4 @@ Version: @VERSION@
 
 Libs: -L${libdir} -lpappl-retrofit
 Libs.private: @CUPS_LIBS@ @CUPSFILTERS_LIBS@ @PPD_LIBS@ @PAPPL_LIBS@
-Cflags: -I${includedir}/pappl-retrofit
+Cflags: -I${includedir}


### PR DESCRIPTION
## Summary

- Add DESTDIR-based staging (`stage-ciroot`) for install-time testing
- Introduce reusable `ci/autopkgtest/run.sh` wrapper
- Run `make test-autopkgtest` in native and emulated CI jobs
- Fix `libpappl-retrofit.pc` include path to match the actual header installation layout
- Verify installed library usage instead of only build-time compilation

This also exposes and fixes a previously hidden pkg-config metadata issue during staged installation testing.