### PR TITLE
Give sidechannel and backchannel its own fd

### DIFF
--- a/pappl-retrofit/cups-backends.c
+++ b/pappl-retrofit/cups-backends.c
@@ -1014,13 +1014,9 @@ _prCUPSDevRead(pappl_device_t *device,
   if (!device_data->backend_pid && !_prCUPSDevLaunchBackend(device))
     return (-1);
 
-  // Standard FD for back channel is 3, the CUPS library functions use
-  // always FD 3. Therefore we redirect our back channel pipe end to
-  // FD 3
-  dup2(device_data->backfd, 3);
-
   // Read from the back channel of the backend
-  return (_prBackChannelRead(buffer, bytes, device_data->back_timeout));
+  return (_prBackChannelRead(device_data->backfd, buffer, bytes,
+			     device_data->back_timeout));
 }
 
 
@@ -1092,13 +1088,9 @@ _prCUPSDevStatus(pappl_device_t *device)
 
   // Query status via side channel
 
-  // Standard FD for side channel is 4, the CUPS library functions
-  // always use FD 4. Therefore we redirect our side channel pipe end
-  // to FD 4
-  dup2(device_data->sidefd, 4);
-
   datalen = 1;
-  if ((sc_status = _prSideChannelDoRequest(_PR_SC_CMD_GET_STATE, &_prStatus,
+  if ((sc_status = _prSideChannelDoRequest(device_data->sidefd,
+					   _PR_SC_CMD_GET_STATE, &_prStatus,
 					   &datalen,
 					   device_data->side_timeout)) !=
       _PR_SC_STATUS_OK)
@@ -1166,13 +1158,9 @@ _prCUPSDevID(pappl_device_t *device,
 
   // Query device ID via side channel
 
-  // Standard FD for side channel is 4, the CUPS library functions
-  // always use FD 4. Therefore we redirect our side channel pipe end
-  // to FD 4
-  dup2(device_data->sidefd, 4);
-
   datalen = bufsize;
-  if ((sc_status = _prSideChannelDoRequest(_PR_SC_CMD_GET_DEVICE_ID,
+  if ((sc_status = _prSideChannelDoRequest(device_data->sidefd,
+					   _PR_SC_CMD_GET_DEVICE_ID,
 					   buffer, &datalen,
 					   device_data->side_timeout)) !=
       _PR_SC_STATUS_OK)

--- a/pappl-retrofit/cups-side-back-channel-private.h
+++ b/pappl-retrofit/cups-side-back-channel-private.h
@@ -38,9 +38,6 @@ extern "C" {
 // Constants...
 //
 
-#define _PR_SC_FD	4		// File descriptor for select/poll
-
-
 //
 // Enumerations...
 //
@@ -118,24 +115,29 @@ typedef void (*pr_sc_walk_func_t)(const char *oid, const char *data,
 // Prototypes...
 //
 
-extern ssize_t		_prBackChannelRead(char *buffer, size_t bytes,
-					   double timeout);
-extern ssize_t		_prBackChannelWrite(const char *buffer, size_t bytes,
-					    double timeout);
-extern pr_sc_status_t	_prSideChannelDoRequest(pr_sc_command_t command,
+extern ssize_t		_prBackChannelRead(int fd, char *buffer,
+					   size_t bytes, double timeout);
+extern ssize_t		_prBackChannelWrite(int fd, const char *buffer,
+					    size_t bytes, double timeout);
+extern pr_sc_status_t	_prSideChannelDoRequest(int fd,
+						pr_sc_command_t command,
 						char *data, int *datalen,
 						double timeout);
-extern int		_prSideChannelRead(pr_sc_command_t *command,
+extern int		_prSideChannelRead(int fd,
+					   pr_sc_command_t *command,
 					   pr_sc_status_t *status,
 					   char *data, int *datalen,
 					   double timeout);
-extern int		_prSideChannelWrite(pr_sc_command_t command,
+extern int		_prSideChannelWrite(int fd,
+					    pr_sc_command_t command,
 					    pr_sc_status_t status,
 					    const char *data, int datalen,
 					    double timeout);
-extern pr_sc_status_t	_prSideChannelSNMPGet(const char *oid, char *data,
-					      int *datalen, double timeout);
-extern pr_sc_status_t	_prSideChannelSNMPWalk(const char *oid, double timeout,
+extern pr_sc_status_t	_prSideChannelSNMPGet(int fd, const char *oid,
+					      char *data, int *datalen,
+					      double timeout);
+extern pr_sc_status_t	_prSideChannelSNMPWalk(int fd, const char *oid,
+					       double timeout,
 					       pr_sc_walk_func_t cb,
 					       void *context);
 

--- a/pappl-retrofit/cups-side-back-channel.c
+++ b/pappl-retrofit/cups-side-back-channel.c
@@ -49,13 +49,14 @@
 static void
 cups_setup(fd_set         *set,		// I - Set for select()
            struct timeval *tval,	// I - Timer value
-	   double         timeout)	// I - Timeout in seconds
+	   double         timeout,	// I - Timeout in seconds
+	   int            fd)		// I - File descriptor
 {
   tval->tv_sec = (time_t)timeout;
   tval->tv_usec = (suseconds_t)(1000000.0 * (timeout - tval->tv_sec));
 
   FD_ZERO(set);
-  FD_SET(3, set);
+  FD_SET(fd, set);
 }
 
 
@@ -68,7 +69,8 @@ cups_setup(fd_set         *set,		// I - Set for select()
 //
 
 ssize_t					// O - Bytes read or -1 on error
-_prBackChannelRead(char   *buffer,	// I - Buffer to read into
+_prBackChannelRead(int    fd,		// I - Back-channel file descriptor
+                    char   *buffer,	// I - Buffer to read into
                     size_t bytes,	// I - Bytes to read
 		    double timeout)	// I - Timeout in seconds, typically
                                         //     0.0 to poll
@@ -84,12 +86,12 @@ _prBackChannelRead(char   *buffer,	// I - Buffer to read into
 
   do
   {
-    cups_setup(&input, &tval, timeout);
+    cups_setup(&input, &tval, timeout, fd);
 
     if (timeout < 0.0)
-      status = select(4, &input, NULL, NULL, NULL);
+      status = select(fd + 1, &input, NULL, NULL, NULL);
     else
-      status = select(4, &input, NULL, NULL, &tval);
+      status = select(fd + 1, &input, NULL, NULL, &tval);
   }
   while (status < 0 && errno != EINTR && errno != EAGAIN);
 
@@ -101,9 +103,9 @@ _prBackChannelRead(char   *buffer,	// I - Buffer to read into
   //
 
 #ifdef _WIN32
-  return ((ssize_t)_read(3, buffer, (unsigned)bytes));
+  return ((ssize_t)_read(fd, buffer, (unsigned)bytes));
 #else
-  return (read(3, buffer, bytes));
+  return (read(fd, buffer, bytes));
 #endif // _WIN32
 }
 
@@ -119,6 +121,7 @@ _prBackChannelRead(char   *buffer,	// I - Buffer to read into
 
 ssize_t					// O - Bytes written or -1 on error
 _prBackChannelWrite(
+    int        fd,			// I - Back-channel file descriptor
     const char *buffer,			// I - Buffer to write
     size_t     bytes,			// I - Bytes to write
     double     timeout)			// I - Timeout in seconds, typically 1.0
@@ -144,12 +147,12 @@ _prBackChannelWrite(
 
     do
     {
-      cups_setup(&output, &tval, timeout);
+      cups_setup(&output, &tval, timeout, fd);
 
       if (timeout < 0.0)
-	status = select(4, NULL, &output, NULL, NULL);
+	status = select(fd + 1, NULL, &output, NULL, NULL);
       else
-	status = select(4, NULL, &output, NULL, &tval);
+	status = select(fd + 1, NULL, &output, NULL, &tval);
     }
     while (status < 0 && errno != EINTR && errno != EAGAIN);
 
@@ -161,9 +164,9 @@ _prBackChannelWrite(
     //
 
 #ifdef _WIN32
-    count = (ssize_t)_write(3, buffer, (unsigned)(bytes - total));
+    count = (ssize_t)_write(fd, buffer, (unsigned)(bytes - total));
 #else
-    count = write(3, buffer, bytes - total);
+    count = write(fd, buffer, bytes - total);
 #endif // _WIN32
 
     if (count < 0)
@@ -207,6 +210,7 @@ _prBackChannelWrite(
 
 pr_sc_status_t				// O  - Status of command
 _prSideChannelDoRequest(
+    int               fd,		// I  - Side-channel file descriptor
     pr_sc_command_t command,		// I  - Command to send
     char              *data,		// O  - Response data buffer pointer
     int               *datalen,		// IO - Size of data buffer on entry,
@@ -218,10 +222,10 @@ _prSideChannelDoRequest(
   pr_sc_command_t	rcommand;	// Response command
 
 
-  if (_prSideChannelWrite(command, _PR_SC_STATUS_NONE, NULL, 0, timeout))
+  if (_prSideChannelWrite(fd, command, _PR_SC_STATUS_NONE, NULL, 0, timeout))
     return (_PR_SC_STATUS_TIMEOUT);
 
-  if (_prSideChannelRead(&rcommand, &status, data, datalen, timeout))
+  if (_prSideChannelRead(fd, &rcommand, &status, data, datalen, timeout))
     return (_PR_SC_STATUS_TIMEOUT);
 
   if (rcommand != command)
@@ -246,6 +250,7 @@ _prSideChannelDoRequest(
 
 int					// O  - 0 on success, -1 on error
 _prSideChannelRead(
+    int               fd,		// I  - Side-channel file descriptor
     pr_sc_command_t *command,		// O  - Command code
     pr_sc_status_t  *status,		// O  - Status code
     char              *data,		// O  - Data buffer pointer
@@ -278,7 +283,7 @@ _prSideChannelRead(
   //
 
 #ifdef HAVE_POLL
-  pfd.fd     = _PR_SC_FD;
+  pfd.fd     = fd;
   pfd.events = POLLIN;
 
   while ((nfds = poll(&pfd, 1,
@@ -288,12 +293,12 @@ _prSideChannelRead(
 
 #else // select()
   FD_ZERO(&input_set);
-  FD_SET(_PR_SC_FD, &input_set);
+  FD_SET(fd, &input_set);
 
   stimeout.tv_sec  = (int)timeout;
   stimeout.tv_usec = (int)(timeout * 1000000) % 1000000;
 
-  while ((nfds = select(_PR_SC_FD + 1, &input_set, NULL, NULL,
+  while ((nfds = select(fd + 1, &input_set, NULL, NULL,
 			timeout < 0.0 ? NULL : &stimeout)) < 0 &&
 	 (errno == EINTR || errno == EAGAIN))
     ;
@@ -326,7 +331,7 @@ _prSideChannelRead(
     return (-1);
   }
 
-  while ((bytes = read(_PR_SC_FD, buffer, _PR_SC_MAX_BUFFER)) < 0)
+  while ((bytes = read(fd, buffer, _PR_SC_MAX_BUFFER)) < 0)
     if (errno != EINTR && errno != EAGAIN)
     {
       free(buffer);
@@ -434,6 +439,7 @@ _prSideChannelRead(
 
 pr_sc_status_t				// O  - Query status
 _prSideChannelSNMPGet(
+    int        fd,			// I  - Side-channel file descriptor
     const char *oid,			// I  - OID to query
     char       *data,			// I  - Buffer for OID value
     int        *datalen,		// IO - Size of OID buffer on entry,
@@ -460,7 +466,7 @@ _prSideChannelSNMPGet(
   // Send the request to the backend and wait for a response...
   //
 
-  if (_prSideChannelWrite(_PR_SC_CMD_SNMP_GET, _PR_SC_STATUS_NONE, oid,
+  if (_prSideChannelWrite(fd, _PR_SC_CMD_SNMP_GET, _PR_SC_STATUS_NONE, oid,
                            (int)strlen(oid) + 1, timeout))
     return (_PR_SC_STATUS_TIMEOUT);
 
@@ -468,7 +474,7 @@ _prSideChannelSNMPGet(
     return (_PR_SC_STATUS_TOO_BIG);
 
   real_datalen = _PR_SC_MAX_BUFFER;
-  if (_prSideChannelRead(&rcommand, &status, real_data, &real_datalen, timeout))
+  if (_prSideChannelRead(fd, &rcommand, &status, real_data, &real_datalen, timeout))
   {
     free(real_data);
     return (_PR_SC_STATUS_TIMEOUT);
@@ -537,6 +543,7 @@ pr_sc_status_t				// O - Status of first query of
                                         //     @code _PR_SC_STATUS_OK@ on
                                         //     success
 _prSideChannelSNMPWalk(
+    int                 fd,		// I - Side-channel file descriptor
     const char          *oid,		// I - First numeric OID to query
     double              timeout,	// I - Timeout for each query in seconds
     pr_sc_walk_func_t cb,		// I - Function to call with each value
@@ -576,7 +583,7 @@ _prSideChannelSNMPWalk(
     // Send the request to the backend and wait for a response...
     //
 
-    if (_prSideChannelWrite(_PR_SC_CMD_SNMP_GET_NEXT, _PR_SC_STATUS_NONE,
+    if (_prSideChannelWrite(fd, _PR_SC_CMD_SNMP_GET_NEXT, _PR_SC_STATUS_NONE,
                              current_oid, (int)strlen(current_oid) + 1, timeout))
     {
       free(real_data);
@@ -584,7 +591,7 @@ _prSideChannelSNMPWalk(
     }
 
     real_datalen = _PR_SC_MAX_BUFFER;
-    if (_prSideChannelRead(&rcommand, &status, real_data, &real_datalen,
+    if (_prSideChannelRead(fd, &rcommand, &status, real_data, &real_datalen,
                             timeout))
     {
       free(real_data);
@@ -651,6 +658,7 @@ _prSideChannelSNMPWalk(
 
 int					// O - 0 on success, -1 on error
 _prSideChannelWrite(
+    int               fd,		// I - Side-channel file descriptor
     pr_sc_command_t command,		// I - Command code
     pr_sc_status_t  status,		// I - Status code
     const char        *data,		// I - Data buffer pointer
@@ -680,7 +688,7 @@ _prSideChannelWrite(
   //
 
 #ifdef HAVE_POLL
-  pfd.fd     = _PR_SC_FD;
+  pfd.fd     = fd;
   pfd.events = POLLOUT;
 
   if (timeout < 0.0)
@@ -693,11 +701,11 @@ _prSideChannelWrite(
 
 #else // select()
   FD_ZERO(&output_set);
-  FD_SET(_PR_SC_FD, &output_set);
+  FD_SET(fd, &output_set);
 
   if (timeout < 0.0)
   {
-    if (select(_PR_SC_FD + 1, NULL, &output_set, NULL, NULL) < 1)
+    if (select(fd + 1, NULL, &output_set, NULL, NULL) < 1)
       return (-1);
   }
   else
@@ -705,7 +713,7 @@ _prSideChannelWrite(
     stimeout.tv_sec  = (int)timeout;
     stimeout.tv_usec = (int)(timeout * 1000000) % 1000000;
 
-    if (select(_PR_SC_FD + 1, NULL, &output_set, NULL, &stimeout) < 1)
+    if (select(fd + 1, NULL, &output_set, NULL, &stimeout) < 1)
       return (-1);
   }
 #endif // HAVE_POLL
@@ -737,7 +745,7 @@ _prSideChannelWrite(
     bytes += datalen;
   }
 
-  while (write(_PR_SC_FD, buffer, (size_t)bytes) < 0)
+  while (write(fd, buffer, (size_t)bytes) < 0)
     if (errno != EINTR && errno != EAGAIN)
     {
       free(buffer);

--- a/pappl-retrofit/pappl-retrofit.c
+++ b/pappl-retrofit/pappl-retrofit.c
@@ -624,13 +624,9 @@ prIdentify(
     if (!device_data->backend_pid && !_prCUPSDevLaunchBackend(device))
       return;
 
-    // Standard FD for the side channel is 4, the CUPS library
-    // functions use always FD 4. Therefore we redirect our side
-    // channel pipe end to FD 4
-    dup2(device_data->sidefd, 4);
-
     datalen = 0;
-    if ((sc_status = _prSideChannelDoRequest(_PR_SC_CMD_SOFT_RESET, NULL,
+    if ((sc_status = _prSideChannelDoRequest(device_data->sidefd,
+					     _PR_SC_CMD_SOFT_RESET, NULL,
 					     &datalen,
 					     device_data->side_timeout)) !=
 	_PR_SC_STATUS_OK)
@@ -3234,14 +3230,10 @@ _prPollDeviceOptionDefaults(
     if (!device_data->backend_pid && !_prCUPSDevLaunchBackend(device))
       return (0);
 
-    // Standard FD for the side channel is 4, the CUPS library
-    // functions use always FD 4. Therefore we redirect our side
-    // channel pipe end to FD 4
-    dup2(device_data->sidefd, 4);
-
     // See if the backend supports bidirectional I/O...
     datalen = 1;
-    if (_prSideChannelDoRequest(_PR_SC_CMD_GET_BIDI, buf, &datalen,
+    if (_prSideChannelDoRequest(device_data->sidefd,
+				_PR_SC_CMD_GET_BIDI, buf, &datalen,
 				5.0) != _PR_SC_STATUS_OK ||
 	buf[0] != _PR_SC_BIDI_SUPPORTED)
     {
@@ -3303,7 +3295,8 @@ _prPollDeviceOptionDefaults(
       sleep(1);
       datalen = 1;
     }
-    while (_prSideChannelDoRequest(_PR_SC_CMD_GET_CONNECTED, buf, &datalen,
+    while (_prSideChannelDoRequest(device_data->sidefd,
+				   _PR_SC_CMD_GET_CONNECTED, buf, &datalen,
 				   device_data->side_timeout) ==
 	   _PR_SC_STATUS_OK && !buf[0]);
   }
@@ -3442,7 +3435,8 @@ _prPollDeviceOptionDefaults(
       {
 	// Flush the data from the backend into the printer
 	datalen = 0;
-	_prSideChannelDoRequest(_PR_SC_CMD_DRAIN_OUTPUT, buf, &datalen,
+	_prSideChannelDoRequest(device_data->sidefd,
+				_PR_SC_CMD_DRAIN_OUTPUT, buf, &datalen,
 				device_data->side_timeout);
       }
       


### PR DESCRIPTION
The current mechanism overrides listening socket fd when identify is called, which blocks the daemon from accepting more requests, starts infinite loop and eat 100% CPU.

The fix gives separate file descriptors to side channel and backchannel of backend, so the daemon is still responsive.

Fixes #32

Assisted-by: Claude Code by Anthropic

@tillkamppeter please do not merge until it is tested.