### PR TITLE
Fix pthread rwlock deadlock in _prStatus callback

### DIFF
--- a/pappl-retrofit/pappl-retrofit.c
+++ b/pappl-retrofit/pappl-retrofit.c
@@ -3820,6 +3820,18 @@ prSetupDeviceSettingsPage(pappl_printer_t *printer, // I - Printer
 
   papplPrinterGetDriverData(printer, &driver_data);
   extension = (pr_driver_extension_t *)driver_data.extension;
+
+  if (!extension->human_strings_resource && extension->human_strings)
+  {
+    papplLogPrinter(printer, PAPPL_LOGLEVEL_DEBUG,
+		    "Registering human-readable strings of the PPD's options for the web interface.");
+    snprintf(path, sizeof(path), "/%s/ui.strings",
+	     papplPrinterGetName(printer));
+    extension->human_strings_resource = strdup(path);
+    papplSystemAddStringsData(system, extension->human_strings_resource,
+			      "en", extension->human_strings);
+  }
+
   if (extension->defaults_pollable ||
       extension->installable_options)
   {
@@ -4401,7 +4413,6 @@ _prStatus(pappl_printer_t *printer) // I - Printer
   pr_printer_app_global_data_t *global_data;
   pappl_device_t	*device;		// Printer device
   pappl_supply_t	supply[32];		// Printer supply information
-  char                  buf[1024];
 
   // Get system...
   system = papplPrinterGetSystem(printer);
@@ -4413,17 +4424,6 @@ _prStatus(pappl_printer_t *printer) // I - Printer
   papplPrinterGetDriverData(printer, &driver_data);
   extension = (pr_driver_extension_t *)driver_data.extension;
   global_data = extension->global_data;
-  if (!extension->human_strings_resource && extension->human_strings)
-  {
-    // Register human-readable strings of vendor options for web interface
-    papplLogPrinter(printer, PAPPL_LOGLEVEL_DEBUG,
-		    "Registering human-readable strings of the PPD's options for the web interface.");
-    snprintf(buf, sizeof(buf), "/%s/ui.strings",
-	     papplPrinterGetName(printer));
-    extension->human_strings_resource = strdup(buf);
-    papplSystemAddStringsData(system, extension->human_strings_resource,
-			      "en", extension->human_strings);
-  }
   if (!extension->updated)
   {
     // Adjust the driver data according to the installed accessories


### PR DESCRIPTION
This commit fixes a deadlock issue that occurs when accessing the web interface.

**Reproduction:**

```
legacy-printer-app server -o backend-directory=/usr/lib/cups/backend & legacy-printer-app add -v cups:smb://some-machine.org/brother  -m "brother--dcp-l-2540-dw--using-owl-maintain-brlaser-v-6-2-7-en" -d "TestBrother" curl http://localhost:8001/
```

**Stack:**

```
0x00007ff049ad9270 in __futex_abstimed_wait_common () from /lib64/libc.so.6 0x00007ff049ae2c8e in pthread_rwlock_wrlock@GLIBC_2.2.5 () from /lib64/libc.so.6 0x00007ff049e15034 in add_resource (system=0x15d98230, r=0x7ff046871f50) at /usr/src/debug/pappl-1.4.9-2.fc43.x86_64/pappl/resource.c:447 0x00007ff049e1d249 in papplSystemAddStringsData (system=0x15d98230, path=0x7ff038006970 "/TestBrother/ui.strings", language=0x7ff04a0ab2f4 "en", data=0x7ff0380d9b80 "\"resolution.600-dpi\" = \"600 DPI\";\n\"resolution.1200-hq\" = \"1200HQ\";\n\"resolution\" = \"Resolution\";\n\"toner-save-mode.off\" = \"Off\";\n\"toner-save-mode.on\" = \"On\";\n\"toner-save-mode\" = \"Toner save mode\";\n") at /usr/src/debug/pappl-1.4.9-2.fc43.x86_64/pappl/resource.c:294 papplSystemAddStringsData (system=system@entry=0x15d98230, path=0x7ff038006970 "/TestBrother/ui.strings", language=language@entry=0x7ff04a0ab2f4 "en", data=0x7ff0380d9b80 "\"resolution.600-dpi\" = \"600 DPI\";\n\"resolution.1200-hq\" = \"1200HQ\";\n\"resolution\" = \"Resolution\";\n\"toner-save-mode.off\" = \"Off\";\n\"toner-save-mode.on\" = \"On\";\n\"toner-save-mode\" = \"Toner save mode\";\n") at /usr/src/debug/pappl-1.4.9-2.fc43.x86_64/pappl/resource.c:273 0x00007ff04a095fa3 in _prStatus (printer=0x7ff038091870) at pappl-retrofit/pappl-retrofit.c:4424 0x00007ff049e03c3a in papplPrinterGetReasons (printer=0x7ff038091870) at /usr/src/debug/pappl-1.4.9-2.fc43.x86_64/pappl/printer-accessors.c:532 papplPrinterGetReasons (printer=0x7ff038091870) at /usr/src/debug/pappl-1.4.9-2.fc43.x86_64/pappl/printer-accessors.c:517 0x00007ff049e19999 in _papplPrinterWebIteratorCallback (printer=0x7ff038091870, client=0x1979c580) at /usr/src/debug/pappl-1.4.9-2.fc43.x86_64/pappl/printer-webif.c:934 0x00007ff049e1ee78 in papplSystemIteratePrinters (system=0x15d98230, cb=0x7ff049e19950 <_papplPrinterWebIteratorCallback>, data=0x1979c580) at /usr/src/debug/pappl-1.4.9-2.fc43.x86_64/pappl/system-accessors.c:1405 papplSystemIteratePrinters (system=0x15d98230, cb=0x7ff049e19950 <_papplPrinterWebIteratorCallback>, data=0x1979c580) at /usr/src/debug/pappl-1.4.9-2.fc43.x86_64/pappl/system-accessors.c:1386 0x00007ff049e290fb in _papplSystemWebHome (client=0x1979c580, system=0x15d98230) at /usr/src/debug/pappl-1.4.9-2.fc43.x86_64/pappl/system-webif.c:725 0x00007ff049df6f9e in _papplClientProcessHTTP (client=client@entry=0x1979c580) at /usr/src/debug/pappl-1.4.9-2.fc43.x86_64/pappl/client.c:372 0x00007ff049df7257 in _papplClientRun (client=0x1979c580) at /usr/src/debug/pappl-1.4.9-2.fc43.x86_64/pappl/client.c:664 0x00007ff049adc464 in start_thread () from /lib64/libc.so.6 0x00007ff049b5f5ec in __clone3 () from /lib64/libc.so.6
```

**Problem:**

The `_prStatus()` callback was lazily registering human-readable strings by calling `papplSystemAddStringsData()` while holding a READ lock of system rwlock.  `papplSystemAddStringsData()` requires a WRITE lock on the same rwlock.  Since pthread rwlocks don't support lock upgrading (read -> write), this causes a permanent deadlock.

**Solution:**

Move the human-readable string registration from `_prStatus()` to `prSetupDeviceSettingsPage()`.  This ensures strings are registered once at printer creation time rather than lazily during status queries.