### PR TITLE
Document CodeQL static-analysis setup in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,3 +517,28 @@ This software is licensed under the Apache License Version 2.0 with an
 exception to allow linking against GPL2/LGPL2 software (like older
 versions of CUPS). See the files "LICENSE" and "NOTICE" for more
 information.
+
+## Continuous Integration and Static Analysis
+
+This repository is checked on every push and pull request by GitHub Actions
+workflows in `.github/workflows/`:
+
+- **Build** (`build.yml`) - builds the project (multi-architecture where
+  applicable) so build/link regressions are caught early.
+- **CodeQL** (`codeql-analysis.yml`) - GitHub's semantic static-analysis engine, using the
+  `security-and-quality` query suite.
+
+### CodeQL Static Analysis Configuration
+
+This repository uses a custom GitHub Actions workflow for CodeQL static analysis located at `.github/workflows/codeql-analysis.yml`. To ensure accurate analysis and avoid conflicts with GitHub's default settings, the following repository configurations are required:
+
+1. **Enable Advanced Setup**:
+   - Go to **Settings** -> **Code security and analysis**.
+   - Under **Code scanning**, locate **CodeQL analysis**.
+   - If "Default" is enabled, click the three dots (...) and select **Switch to advanced**.
+2. **Disable Default Setup**:
+   - The "Default" setup must be disabled for the custom workflow to upload results successfully.
+3. **Custom Workflow Dependencies**:
+   - Our custom workflow is designed to install specific project dependencies and perform a manual build before the analysis. This ensures that CodeQL has a complete build graph for the C sources in this repository.
+
+*Note: If the Default setup is active, GitHub may reject the results uploaded by the manual workflow, causing the CI job to fail.*


### PR DESCRIPTION
This documents the custom CodeQL static-analysis setup in the README, matching the rest of the OpenPrinting stack.

The repository's CodeQL workflow is a **custom** workflow that installs the project's dependencies and performs a manual build so CodeQL gets a complete build graph. For that to work the repository must be switched to CodeQL **advanced** setup (default setup disabled), otherwise GitHub rejects the results uploaded by the manual workflow and the CI job fails. This PR spells that requirement out.

Docs-only change.
