### PR TITLE
Fix cppcheck findings in cups-backends, pappl-retrofit and print-job

### DIFF
--- a/pappl-retrofit/cups-backends.c
+++ b/pappl-retrofit/cups-backends.c
@@ -173,7 +173,7 @@ _prCUPSSigchldSigAction(int sig,		// I - Signal number (unused)
 
   // One of the backends terminated, mark it as done and add the status
   // to its record
-  for (i = 0; backend_list[i].name && i < MAX_BACKENDS; i ++)
+  for (i = 0; i < MAX_BACKENDS && backend_list[i].name; i ++)
     if (backend_list[i].pid == info->si_pid)
     {
       papplLog(global_data->system, PAPPL_LOGLEVEL_DEBUG,

--- a/pappl-retrofit/pappl-retrofit.c
+++ b/pappl-retrofit/pappl-retrofit.c
@@ -954,7 +954,7 @@ _prPPDMissingFilters(int num_filters,          // I - Number of filter
     if (!filter_name[0])
       continue;
 
-    if (!filter_name[0] || strcmp(filter_name, "-") == 0)
+    if (strcmp(filter_name, "-") == 0)
       // Null filter ("-")
       continue;
     else if ((filter_path = _prCUPSFilterPath(filter_name, filter_dir)) ==

--- a/pappl-retrofit/print-job.c
+++ b/pappl-retrofit/print-job.c
@@ -2114,7 +2114,7 @@ prPSRasterStartPage(
   _prOneBitDitherOnDraft(job, options);
 
   // DSC header
-  fprintf(devout, "%%%%Page: (%d) %d\n", page, page);
+  fprintf(devout, "%%%%Page: (%u) %u\n", page, page);
   fputs("%%BeginPageSetup\n", devout);
   ppdEmit(job_data->ppd, devout, PPD_ORDER_PAGE);
   fputs("%%EndPageSetup\n", devout);


### PR DESCRIPTION
cppcheck flagged a few issues; this fixes them.

- `cups-backends.c`: check `i < MAX_BACKENDS` before indexing `backend_list[i]` in the SIGCHLD loop (array index used before the limit check).
- `pappl-retrofit.c`: drop the redundant `!filter_name[0]` term in `_prPPDMissingFilters`; it is already handled by the early `continue` just above, so it was always false.
- `print-job.c`: use `%u` for the `unsigned` page number in the DSC `%%Page:` line.
