### PR TITLE
Add cppcheck static-analysis CI

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,0 +1,34 @@
+name: cppcheck
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+  workflow_dispatch:
+
+jobs:
+  cppcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install cppcheck
+        run: |
+          # Retry to ride out transient Ubuntu mirror sync failures (matches build.yml)
+          sudo apt-get update -o Acquire::Retries=3
+          sudo apt-get install -y -o Acquire::Retries=3 cppcheck
+
+      - name: Run cppcheck
+        run: |
+          cppcheck \
+            --enable=warning,performance,portability \
+            --error-exitcode=1 \
+            --inline-suppr \
+            --suppress=missingIncludeSystem \
+            --suppress=unknownMacro \
+            -DVERSION="$(grep -oP 'AC_INIT\(\[[^\]]*\],\s*\[\K[^\]]*' configure.ac)" \
+            .


### PR DESCRIPTION
Adds a cppcheck static-analysis workflow, matching the rest of the OpenPrinting stack (same invocation as cups-filters: `--enable=warning,performance,portability --error-exitcode=1`). It runs on every push and pull request.

The pre-existing findings cppcheck surfaced were fixed first in #55, which is already merged, so this workflow is green.
